### PR TITLE
Fix publish not triggering after release creation

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      released: ${{ steps.check.outputs.proceed }}
     steps:
       - uses: actions/checkout@v4
 
@@ -45,3 +47,12 @@ jobs:
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
             --generate-notes
+
+  publish:
+    name: Pack and Publish
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    uses: ./.github/workflows/pack-and-publish.yaml
+    permissions:
+      id-token: write
+      contents: read

--- a/.github/workflows/pack-and-publish.yaml
+++ b/.github/workflows/pack-and-publish.yaml
@@ -3,6 +3,7 @@ name: Pack and Publish
 on:
   release:
     types: [published]
+  workflow_call:
 
 jobs:
   build:


### PR DESCRIPTION
GITHUB_TOKEN cannot trigger other workflows, so instead of relying on the release event to chain into pack-and-publish, use workflow_call to invoke it directly from create-release. The release job exposes a 'released' output so the publish job is skipped when the version check fails.

https://claude.ai/code/session_012rfa6vEh3Lp3VYmk1VYBCA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release and publishing automation by enhancing workflow orchestration and enabling conditional publishing upon successful release creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->